### PR TITLE
Transform the node with found index (richcontent)

### DIFF
--- a/app/src/main/java/ch/benediktkoeppel/code/droidplane/MindmapNode.java
+++ b/app/src/main/java/ch/benediktkoeppel/code/droidplane/MindmapNode.java
@@ -167,7 +167,7 @@ public class MindmapNode {
                     try {
                         Transformer transformer = TransformerFactory.newInstance().newTransformer();
                         ByteArrayOutputStream boas = new ByteArrayOutputStream();
-                        transformer.transform(new DOMSource(richtextNodeList.item(0)), new StreamResult(boas));
+                        transformer.transform(new DOMSource(richtextNodeList.item(i)), new StreamResult(boas));
                         richTextContent = boas.toString();
                     } catch (TransformerException e) {
                         e.printStackTrace();


### PR DESCRIPTION
When extracting richcontent, the MindmapNode constructor finds DETAILS node index, but then transforms the one at index 0. It seems to work with nodes at higher levels, but nodes at the "level 1" have other stuff at index 0.
